### PR TITLE
docs: clarify Panther connector requires GraphQL API URL

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -29,7 +29,16 @@ In Panther, click the gear icon in the top menu bar and select **API Tokens**.
 </Step>
 <Step>
 
-Make a note of the **API URL** shown at the top of the page. 
+Make a note of the **GraphQL API URL** shown at the top of the page. Panther displays two API URLs: use the **GraphQL API URL** (ending in `/public/graphql`), not the REST API URL.
+
+<Info>
+The GraphQL API URL format depends on your deployment type:
+
+- **SaaS**: `https://api.{your-tenant}.runpanther.net/public/graphql`
+- **Self-hosted**: `https://{your-domain}/v1/public/graphql`
+
+The C1 connector requires this URL to authenticate and sync data.
+</Info>
 </Step>
 <Step>
 Click **Create New Token**.
@@ -98,7 +107,7 @@ Click **Next**.
 Find the **Settings** area of the page and click **Edit**.
 </Step>
 <Step>
-In the **API key** and **API URL** fields, enter the credentials you created in Panther.
+In the **API key** and **API URL** fields, enter the credentials you created in Panther. For the **API URL**, use the **GraphQL API URL** (ending in `/public/graphql`).
 </Step>
 <Step>
 Click **Save**.
@@ -173,7 +182,7 @@ stringData:
   
   # Panther credentials
   BATON_TOKEN: <Panther API token>
-  BATON_URL: <API URL of your Panther account>
+  BATON_URL: <GraphQL API URL of your Panther account (ending in /public/graphql)>
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -77,8 +77,6 @@ To complete this task, you'll need:
 <Tab title="Cloud-hosted">
 **Follow these instructions to use a built-in, no-code connector hosted by C1.**
 
-**Follow these instructions to use a built-in, no-code connector hosted by C1.**
-
 <Steps>
 <Step>
 In C1, navigate to **Integrations** > **Connectors** and click **Add connector**.


### PR DESCRIPTION
## Summary

Mirrors the changes from ConductorOne/docs#247 in the source connector doc.

- Updated credential-gathering step to specify **GraphQL API URL**, not just "API URL"
- Added `<Info>` callout showing the URL format for both SaaS and self-hosted deployments
- Clarified the API URL field in the cloud-hosted setup step
- Updated `BATON_URL` placeholder in the Kubernetes secrets config

## Context

Panther exposes two API URLs. The connector uses GraphQL queries and POSTs directly to the provided URL, so users who paste the REST URL get auth failures. The info callout covers both deployment types:
- **SaaS**: `https://api.{your-tenant}.runpanther.net/public/graphql`
- **Self-hosted**: `https://{your-domain}/v1/public/graphql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)